### PR TITLE
Make get_tld return eTLD

### DIFF
--- a/src/publicsuffix2/__init__.py
+++ b/src/publicsuffix2/__init__.py
@@ -254,7 +254,9 @@ class PublicSuffixList(object):
             return None
         parts = domain.lower().strip('.').split('.')
         hits = [None] * len(parts)
-        if strict and parts[-1] not in self.root[1].keys():
+        if strict and (
+            self.root in (0, 1) or parts[-1] not in self.root[1].keys()
+        ):
             return None
 
         self._lookup_node(hits, 1, self.root, parts, wildcard)

--- a/src/publicsuffix2/__init__.py
+++ b/src/publicsuffix2/__init__.py
@@ -231,14 +231,7 @@ class PublicSuffixList(object):
             for name in ('*', parts[-depth]):
                 child = children.get(name, None)
                 if child is not None:
-                    if wildcard:
-                        if child in (0, 1):
-                            negate = child
-                        else:
-                            negate = child[0]
-                        matches[-depth] = negate
-                        self._lookup_node(matches, depth + 1, child, parts, wildcard)
-                    elif name != '*':
+                    if wildcard or name != '*':
                         if child in (0, 1):
                             negate = child
                         else:

--- a/tests.py
+++ b/tests.py
@@ -248,9 +248,12 @@ class TestPublicSuffixIdna(unittest.TestCase):
         self.assertEqual(psl.get_tld('blah.local', wildcard=False), None)
         self.assertEqual(psl.get_tld('blah.local'), 'local')
 
+        # FQDNs
+        self.assertEqual(psl.get_tld('www.foo.com.'), 'com')
+        self.assertEqual(psl.get_tld('.'), '')  # the root domain
+
         # the tld for empty string
         self.assertEqual(psl.get_tld(''), None)
-        self.assertEqual(psl.get_tld('.'), '')  # XXX: Is it correct?
 
     def test_PublicSuffixList_tlds_is_loaded_correctly(self):
         psl = publicsuffix.PublicSuffixList()
@@ -279,9 +282,12 @@ class TestPublicSuffixIssue5(unittest.TestCase):
         self.assertEqual(psl.get_sld(''), None)
         self.assertEqual(psl.get_sld('', strict=True), None)
         self.assertEqual(psl.get_sld('', wildcard=False), None)
-        self.assertEqual(psl.get_sld('.'), '')  # XXX: Is it correct?
-        self.assertEqual(psl.get_sld('.', strict=True), None)
-        self.assertEqual(psl.get_sld('.', wildcard=False), '')  # XXX: Is it correct?
+
+        # FQDNs
+        self.assertEqual(psl.get_sld('www.foo.com.'), 'foo.com')
+        self.assertEqual(psl.get_sld('.'), '')  # the root domain
+        self.assertEqual(psl.get_sld('.', strict=True), None)  # the root domain
+        self.assertEqual(psl.get_sld('.', wildcard=False), '')  # the root domain
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -61,7 +61,7 @@ class TestPublicSuffix(unittest.TestCase):
         assert 'com' == psl.get_sld('a.example.com')
 
         # enable strict mode
-        # assert None == psl.get_sld('com', strict=True)  # FIXME
+        assert None == psl.get_sld('com', strict=True)
 
     def test_get_sld_from_list(self):
         psl = publicsuffix.PublicSuffixList(['com'])

--- a/tests.py
+++ b/tests.py
@@ -235,17 +235,17 @@ class TestPublicSuffixIdna(unittest.TestCase):
         # checks that the eTLD or TLD is produced
         assert psl.get_tld('com') == 'com'
         self.assertEqual(psl.get_tld('city.kobe.jp'), 'kobe.jp')
-        self.assertEqual(psl.get_tld('kobe.jp'), 'jp')  # FIXME: 'kobe.jp'
-        self.assertEqual(psl.get_tld('amazonaws.com'), 'com')  # FIXME: 'amazonaws.com'
+        self.assertEqual(psl.get_tld('kobe.jp'), 'kobe.jp')
+        self.assertEqual(psl.get_tld('amazonaws.com'), 'amazonaws.com')
         assert psl.get_tld('telinet.com.pg', wildcard=True) == 'com.pg'
         assert psl.get_tld('telinet.com.pg', wildcard=False) == 'pg'
-        self.assertEqual(psl.get_tld('com.pg', wildcard=True), 'pg')  # FIXME: 'com.pg'
+        self.assertEqual(psl.get_tld('com.pg', wildcard=True), 'com.pg')
         self.assertEqual(psl.get_tld('com.pg', wildcard=False), 'pg')
         assert psl.get_tld('telinet.co.uk', wildcard=False) == 'co.uk'
-        self.assertEqual(psl.get_tld('co.uk', wildcard=True), 'uk')  # FIXME: 'co.uk'
-        self.assertEqual(psl.get_tld('co.uk', wildcard=False), 'uk')  # FIXME: 'co.uk'
+        self.assertEqual(psl.get_tld('co.uk', wildcard=True), 'co.uk')
+        self.assertEqual(psl.get_tld('co.uk', wildcard=False), 'co.uk')
         assert psl.get_tld('blah.local', strict=True) is None
-        self.assertEqual(psl.get_tld('blah.local', wildcard=False), 'local')  # FIXME: None
+        self.assertEqual(psl.get_tld('blah.local', wildcard=False), None)
         self.assertEqual(psl.get_tld('blah.local'), 'local')
 
         # the tld for empty string


### PR DESCRIPTION
This PR fix #5 .

> if get_tld was modified to always return the eTLD itself
