### PR TITLE
docs: note that get_sld returns eTLD as is

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,8 @@ or second-level-doamin; get_public_suffix() and get_sld()::
     'example.co.uk'
     >>> get_public_suffix('www.super.example.co.uk')
     'example.co.uk'
+    >>> get_sld("co.uk")  # returns eTLD as is
+    'co.uk'
 
 This function loads and caches the public suffix list. To obtain the latest version of the
 PSL, use the fetch() function to first download the latest version. Alternatively, you can pass

--- a/src/publicsuffix2/__init__.py
+++ b/src/publicsuffix2/__init__.py
@@ -245,6 +245,9 @@ class PublicSuffixList(object):
         for example, 'www.this.local' will return 'this.local'. If you want to
         ensure the TLD is in the public suffix list, use strict=True.
 
+        If domain is already an eTLD, it returns domain as-is instead of None
+        value.
+
         :param domain: string, needs to match the encoding of the PSL (idna or UTF8)
         :param wildcard: boolean, follow wildcard patterns
         :param strict: boolean, check the TLD is valid, return None if not


### PR DESCRIPTION
A fix of #5 .

> we can add to the documentation that in the event you pass an TLD/eTLD, the return value will be an TLD/eTLD.