### PR TITLE
Fixing two typos in the "History" section of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,7 @@ Copyright (c) 2014 Tomaž Šolc <tomaz.solc@tablix.org>
 
 David Wilson's code was originally at:
 
-from http://code.google.com/p/python-public-suffix-list/
+http://code.google.com/p/python-public-suffix-list/
 
 Copyright (c) 2009 David Wilson
 

--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ History
 -------
 This code is forked from Tomaž Šolc's fork of David Wilson's code.
 
-David Wilson's code originally at:
+Tomaž Šolc's code originally at:
 
 https://www.tablix.org/~avian/git/publicsuffix.git
 


### PR DESCRIPTION
Hi Philippe,

this change fixes two small errors: there was a mistake in the label above the *tablix.org/...* URL and there was an unnecessary "from" before the *code.google.com* URL.

Thanks continuing the development of this library and for nicely crediting the previous maintainers!