### PR TITLE
Update MANIFEST.in so tests are in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,7 @@ graft src
 include CHANGELOG.rst
 include README.rst
 include publicsuffix2.LICENSE
+include tests.py
+include tests_mozilla.py
 
 global-exclude *.py[co] __pycache__ *.so *.pyd


### PR DESCRIPTION
I've just packaged publicsuffix2 for Debian (so we can get rid of publicsuffix).  We like to run the package tests are part of our QA process, so it would be nice if they were included in the sdist.