### PR TITLE
make get_tld return only eTLDs in the publicsuffix list

### DIFF
--- a/src/publicsuffix2/__init__.py
+++ b/src/publicsuffix2/__init__.py
@@ -231,14 +231,17 @@ class PublicSuffixList(object):
             for name in ('*', parts[-depth]):
                 child = children.get(name, None)
                 if child is not None:
-                    if wildcard or name != '*':
-                        if child in (-1, 0, 1):
-                            negate = child
-                        else:
-                            negate = child[0]
-                        if negate != -1:
-                            matches[-depth] = negate
-                        self._lookup_node(matches, depth + 1, child, parts, wildcard)
+                    if child in (-1, 0, 1):
+                        negate = child
+                    else:
+                        negate = child[0]
+                    if name == '*' and not wildcard:
+                        # negates '*' to select a name to the right of "*" ()
+                        # See: https://github.com/nexB/python-publicsuffix2/pull/19/files#r458703338
+                        matches[-depth] = 1
+                    elif negate != -1:
+                        matches[-depth] = negate
+                    self._lookup_node(matches, depth + 1, child, parts, wildcard)
 
     def get_sld(self, domain, wildcard=True, strict=False):
         """

--- a/tests.py
+++ b/tests.py
@@ -212,8 +212,8 @@ class TestPublicSuffixGetSldIdna(unittest.TestCase):
     def test_get_sld_no_wildcard(self):
         psl = publicsuffix.PublicSuffixList()
         # test completion when no wildcards should be processed
-        assert 'com.pg' == psl.get_sld('telinet.com.pg', wildcard=False)
-        expected = 'ap-southeast-1.elb.amazonaws.com'
+        assert 'pg' == psl.get_sld('telinet.com.pg', wildcard=False)
+        expected = 'amazonaws.com'
         result = psl.get_sld('blah.ap-southeast-1.elb.amazonaws.com', wildcard=False)
         assert expected == result
 
@@ -226,19 +226,26 @@ class TestPublicSuffixGetSldIdna(unittest.TestCase):
     def test_get_tld_returns_correct_tld_or_etld(self):
         psl = publicsuffix.PublicSuffixList()
         assert 'com' == psl.get_tld('com')
+        assert 'ck' == psl.get_tld('ck')
         assert 'kobe.jp' == psl.get_tld('city.kobe.jp')
-        assert 'kobe.jp' == psl.get_tld('kobe.jp')
-        assert 'amazonaws.com' == psl.get_tld('amazonaws.com')
+        assert 'jp' == psl.get_tld('kobe.jp')
+        assert 'com' == psl.get_tld('amazonaws.com')
         assert 'com.pg' == psl.get_tld('telinet.com.pg', wildcard=True)
-        assert 'pg' == psl.get_tld('telinet.com.pg', wildcard=False)
+        assert None == psl.get_tld('telinet.com.pg', wildcard=False)
         assert 'com.pg' == psl.get_tld('com.pg', wildcard=True)
-        assert 'pg' == psl.get_tld('com.pg', wildcard=False)
+        assert None == psl.get_tld('com.pg', wildcard=False)
         assert 'co.uk' == psl.get_tld('telinet.co.uk', wildcard=False)
         assert 'co.uk' == psl.get_tld('co.uk', wildcard=True)
         assert 'co.uk' == psl.get_tld('co.uk', wildcard=False)
         assert None == psl.get_tld('blah.local', strict=True)
         assert None == psl.get_tld('blah.local', wildcard=False)
         assert 'local' == psl.get_tld('blah.local')
+
+        # See #18
+        assert 'git-pages.rit.edu' == psl.get_tld('git-pages.rit.edu')
+        assert 'edu' == psl.get_tld('rit.edu')
+        assert 'edu' == psl.get_tld('edu')
+        assert 'com' == psl.get_tld('cdn.fbsbx.com')
 
     def test_get_tld_returns_correct_tld_or_etld_for_fqdn(self):
         psl = publicsuffix.PublicSuffixList()

--- a/tests.py
+++ b/tests.py
@@ -212,8 +212,8 @@ class TestPublicSuffixGetSldIdna(unittest.TestCase):
     def test_get_sld_no_wildcard(self):
         psl = publicsuffix.PublicSuffixList()
         # test completion when no wildcards should be processed
-        assert 'pg' == psl.get_sld('telinet.com.pg', wildcard=False)
-        expected = 'amazonaws.com'
+        assert 'com.pg' == psl.get_sld('telinet.com.pg', wildcard=False)
+        expected = 'ap-southeast-1.elb.amazonaws.com'
         result = psl.get_sld('blah.ap-southeast-1.elb.amazonaws.com', wildcard=False)
         assert expected == result
 
@@ -231,9 +231,9 @@ class TestPublicSuffixGetSldIdna(unittest.TestCase):
         assert 'jp' == psl.get_tld('kobe.jp')
         assert 'com' == psl.get_tld('amazonaws.com')
         assert 'com.pg' == psl.get_tld('telinet.com.pg', wildcard=True)
-        assert None == psl.get_tld('telinet.com.pg', wildcard=False)
+        assert 'pg' == psl.get_tld('telinet.com.pg', wildcard=False)
         assert 'com.pg' == psl.get_tld('com.pg', wildcard=True)
-        assert None == psl.get_tld('com.pg', wildcard=False)
+        assert 'pg' == psl.get_tld('com.pg', wildcard=False)
         assert 'co.uk' == psl.get_tld('telinet.co.uk', wildcard=False)
         assert 'co.uk' == psl.get_tld('co.uk', wildcard=True)
         assert 'co.uk' == psl.get_tld('co.uk', wildcard=False)


### PR DESCRIPTION
See: #18

To solve the problem, I initialize the trie with `-1`. `-1` means that there are no definitions in the publicsuffix list.

This is WIP PR because I don't really understand the exact semantics of `wildcard=False` .