### PR TITLE
Add option to exclude private PSL names and associated test

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -256,6 +256,10 @@ class TestPublicSuffixGetSldIdna(unittest.TestCase):
         psl = publicsuffix.PublicSuffixList()
         assert psl.tlds
 
+    def test_get_tld_no_private(self):
+        psl = publicsuffix.PublicSuffixList(private=False)
+        # Without private, ap-northeast-1.elasticbeanstalk.com is com
+        assert 'com' == psl.get_tld('ap-northeast-1.elasticbeanstalk.com')
 
 class TestPublicSuffixGetSld(unittest.TestCase):
 


### PR DESCRIPTION
Currently on the IETF DMARC Working Group mailing list there is discussion about how for DMARC's use of the PSL it might be better to exclude the private names portion of the PSL from consideration.  It would be nice to be able to support analysis on this point in Python, so I implemented an option to exclude the private names.

It seems like this might be more generally useful, so here you go.  Ideally it'd be nice to see  a release with this.  There shouldn't be any backward compatibility issues and an appropriate test is included.  All existing tests pass.